### PR TITLE
Fixed Pan with 0 as argument

### DIFF
--- a/src/dsp/Pan.js
+++ b/src/dsp/Pan.js
@@ -28,8 +28,10 @@ var Pan = function(audiolet, pan) {
     AudioletNode.call(this, audiolet, 2, 1);
     // Hardcode two output channels
     this.setNumberOfOutputChannels(0, 2);
-    this.pan = new AudioletParameter(this, 1, pan || 0.5);
-};
+    if (pan == null) {
+    	var pan = 0.5;
+    }
+    this.pan = new AudioletParameter(this, 1, pan);};
 extend(Pan, AudioletNode);
 
 /**

--- a/src/dsp/Pan.js
+++ b/src/dsp/Pan.js
@@ -31,7 +31,8 @@ var Pan = function(audiolet, pan) {
     if (pan == null) {
     	var pan = 0.5;
     }
-    this.pan = new AudioletParameter(this, 1, pan);};
+    this.pan = new AudioletParameter(this, 1, pan);
+};
 extend(Pan, AudioletNode);
 
 /**


### PR DESCRIPTION
Hi there Joe,
When you used 

``` javascript
this.pan = new AudioletParameter(this, 1, pan || 0.5);
```

passing 0 or 0.0 as an argument resulted in a pan in the middle, since 0 in logic is false. I added in a little thing to detect a null value.
Hope this helps.
Thanks again for your awesome work on this project.
