### PR TITLE
adding midi control groups

### DIFF
--- a/examples/arpeggiator/index.htm
+++ b/examples/arpeggiator/index.htm
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Audiolet - Arpeggiator Example</title>
+    <!-- Production -->
+    <!--
+    <script src="../../src/audiolet/Audiolet.min.js"></script>
+    -->
+
+    <!-- Development -->
+    <script src="../../src/audiolet/Audiolet.js"></script>
+    <script src="../../src/midi/MidiOutput.js"></script>
+    <script src="../../src/midi/MidiInput.js"></script>
+    <script src="../../src/midi/MidiGroup.js"></script>
+    <script src="../../src/midi/MidiKeyboard.js"></script>
+    <script src="../../src/midi/Instrument.js"></script>
+    <script src="../../src/midi/Arpeggiator.js"></script>
+
+    <!-- Common -->
+    <script src="js/arpeggiator.js"></script>
+    <link rel="stylesheet" href="../support/main.css" />
+    <link href='http://fonts.googleapis.com/css?family=Lato:400,700|Inconsolata' rel='stylesheet' type='text/css'>
+  </head>
+  <body>
+    <div id="wrap">
+      <header>
+        <h1>Audiolet - Arpeggiator Example</h1>
+      </header>
+      <section id="abstract">
+        <p>This demonstrates a simple MIDI chain where an arpeggiator controls an instrument.</p>
+      </section>
+      <section id="play">
+        <button type="button" onclick="playExample()">&#9654; Play Example</button>
+      </section>
+      <section class="code-block">
+        <pre><h2>js/arpeggiator.js</h2>
+          <code>
+var audiolet = new Audiolet(),
+  arpeggiator = new Arpeggiator(audiolet),
+  instrument = new Instrument(audiolet);
+
+arpeggiator.connect(instrument);
+instrument.connect(audiolet.output);
+
+function playExample() {
+    arpeggiator.noteOn(71, 255);
+}
+</code></pre>
+      </section>
+    </div>
+    <footer>
+        &copy; 2011 <a href="http://oampo.github.com/Audiolet/" target="_blank">Audiolet</a> &mdash; Code Highlighting by <a href="https://github.com/cloudhead/hijs" target="_blank">hijs</a>
+      </footer>
+    <script src="../support/hijs.js" type="text/javascript" charset="utf-8"></script>
+  </body>
+</html>

--- a/examples/arpeggiator/js/arpeggiator.js
+++ b/examples/arpeggiator/js/arpeggiator.js
@@ -1,0 +1,10 @@
+var audiolet = new Audiolet(),
+  arpeggiator = new Arpeggiator(audiolet),
+  instrument = new Instrument(audiolet);
+
+arpeggiator.connect(instrument);
+instrument.connect(audiolet.output);
+
+function playExample() {
+    arpeggiator.noteOn(71, 255);
+}

--- a/examples/midi-control/index.htm
+++ b/examples/midi-control/index.htm
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Audiolet - MIDI Control Example</title>
+    <!-- Production -->
+    <!--
+    <script src="../../src/audiolet/Audiolet.min.js"></script>
+    -->
+
+    <!-- Development -->
+    <script src="../../src/audiolet/Audiolet.js"></script>
+    <script src="../../src/midi/MidiOutput.js"></script>
+    <script src="../../src/midi/MidiInput.js"></script>
+    <script src="../../src/midi/MidiGroup.js"></script>
+    <script src="../../src/midi/MidiKeyboard.js"></script>
+    <script src="../../src/midi/Instrument.js"></script>
+
+    <!-- Common -->
+    <script src="js/midi-control.js"></script>
+    <link rel="stylesheet" href="../support/main.css" />
+    <link href='http://fonts.googleapis.com/css?family=Lato:400,700|Inconsolata' rel='stylesheet' type='text/css'>
+  </head>
+  <body>
+    <div id="wrap">
+      <header>
+        <h1>Audiolet - MIDI Control Example</h1>
+      </header>
+      <section id="abstract">
+        <p>This demonstrates a simple MIDI chain where a keyboard controls an instrument. Click on the document and use your a, w, s, e, d, r, f, g, y, h, u, j, k, o, l, and p keys to make noises.</p>
+      </section>
+      <section class="code-block">
+        <pre><h2>js/midi-control.js</h2>
+          <code>
+var audiolet = new Audiolet(),
+    keyboard = new MidiKeyboard(audiolet),
+    instrument = new Instrument(audiolet);
+
+keyboard.connect(instrument);
+instrument.connect(audiolet.output);
+</code></pre>
+      </section>
+    </div>
+    <footer>
+        &copy; 2011 <a href="http://oampo.github.com/Audiolet/" target="_blank">Audiolet</a> &mdash; Code Highlighting by <a href="https://github.com/cloudhead/hijs" target="_blank">hijs</a>
+      </footer>
+    <script src="../support/hijs.js" type="text/javascript" charset="utf-8"></script>
+  </body>
+</html>

--- a/examples/midi-control/js/midi-control.js
+++ b/examples/midi-control/js/midi-control.js
@@ -1,0 +1,6 @@
+var audiolet = new Audiolet(),
+    keyboard = new MidiKeyboard(audiolet),
+    instrument = new Instrument(audiolet);
+
+keyboard.connect(instrument);
+instrument.connect(audiolet.output);

--- a/src/midi/Arpeggiator.js
+++ b/src/midi/Arpeggiator.js
@@ -1,4 +1,11 @@
-var Arpeggiator = function(audiolet) {
+/**
+ * An Arpeggiator is a MidiGroup which modifies the MIDI messages on
+ * input 0, and forwards the newly generated messages on output 0.
+ *
+ * @constructor
+ * @param {Audiolet} audiolet The audiolet object.
+ */
+ var Arpeggiator = function(audiolet) {
     MidiGroup.call(this, audiolet, 1, 1, 0, 0);
     this.key_cancel_map = {};
 };

--- a/src/midi/Arpeggiator.js
+++ b/src/midi/Arpeggiator.js
@@ -1,0 +1,40 @@
+var Arpeggiator = function(audiolet) {
+    MidiGroup.call(this, audiolet, 1, 1, 0, 0);
+    this.key_cancel_map = {};
+};
+extend(Arpeggiator, MidiGroup);
+
+Arpeggiator.prototype.noteOn = function(key, vel) {
+
+    var self = this,
+        midiOut = this.outputs[0],
+        startKey = key,
+        scheduler = this.audiolet.scheduler,
+        phase = 0,
+        down = false;
+
+    // start note
+    midiOut.send(144, key, vel);
+
+    // cycle stops previous note and starts new note
+    var e = scheduler.play(
+        new PSequence([1, 0], Infinity),
+        1/4,
+        function() {
+            midiOut.send(128, key, vel);
+            key = down? key - 3: key + 3;
+            phase = down? phase - 1: phase + 1,
+            down = down? phase != -3: phase == 3;
+            midiOut.send(144, key, vel);
+        });
+
+    self.key_cancel_map[startKey] = function() {
+        scheduler.stop(e);
+        midiOut.send(128, key, vel);
+    };
+
+}
+
+Arpeggiator.prototype.noteOff = function(key, vel) {
+    this.key_cancel_map[key]();
+};

--- a/src/midi/Instrument.js
+++ b/src/midi/Instrument.js
@@ -1,4 +1,11 @@
-var Instrument = function(audiolet) {
+/**
+ * An Instrument is a MidiGroup which controls a set of generators (voices)
+ * based on noteOn and noteOff messages.
+ *
+ * @constructor
+ * @param {Audiolet} audiolet The audiolet object.
+ */
+ var Instrument = function(audiolet) {
     MidiGroup.call(this, audiolet, 1, 1, 0, null);
     this.createVoice = function(frequency) { return new Sine(audiolet, frequency); };
     this._voices = {};

--- a/src/midi/Instrument.js
+++ b/src/midi/Instrument.js
@@ -1,0 +1,37 @@
+var Instrument = function(audiolet) {
+    MidiGroup.call(this, audiolet, 1, 1, 0, null);
+    this.createVoice = function(frequency) { return new Sine(audiolet, frequency); };
+    this._voices = {};
+};
+extend(Instrument, MidiGroup);
+
+// this maps midi key values to `voice` objects
+// for instance, midi key `71` maps to { key: 'C', octave: 4 }
+Instrument.prototype.scale = (function() {
+
+  var midi_to_key = {},
+      scale = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#',
+          'G', 'G#', 'A', 'A#', 'B'];
+
+  var msg = 0;
+  for (var octave = -2, msg = 0; octave <= 8; octave++) {
+      for (var i = 0; i < scale.length; i++, msg++) {
+          midi_to_key[msg] = { key: scale[i], octave: octave };
+      };
+  };
+
+  return midi_to_key;
+
+})();
+
+Instrument.prototype.noteOn = function(key, vel) {
+    console.log('got note on', this.scale[key].key, this.scale[key].octave);
+    var frequency = (key * 8),
+        voice = new this.createVoice(frequency);
+    voice.connect(this.outputs[0]);
+    this._voices[key] = voice;
+};
+
+Instrument.prototype.noteOff = function(key, vel) {
+    this._voices[key].remove();
+};

--- a/src/midi/MidiGroup.js
+++ b/src/midi/MidiGroup.js
@@ -1,16 +1,20 @@
 /**
- * A container for collections of connected AudioletNodes.  Groups make it
- * possible to create multiple copies of predefined networks of nodes,
- * without having to manually create and connect up each individual node.
+ * A MidiGroup is almost identical to an AudioletGroup, except it
+ * let's you define which input and output index represent MidiInputs
+ * and MidIOutputs. It additionally provides a `midi` method which
+ * maps midi messages to instance methods. `.midi(144, 44, 255)` for instance,
+ * will trigger .noteOn(44, 255);.
  *
- * From the outside groups look and behave exactly the same as nodes.
- * Internally you can connect nodes directly to the group's inputs and
- * outputs, allowing connection to nodes outside of the group.
+ * The MidiInput, MidiOutput, and MidiGroup nodes all behave the same as Audiolet
+ * objects for routing purposes- but `MidiOutput` has a unique method; `send`.
+ * `send` will send a midi message to the node that output is connected to. 
  *
  * @constructor
  * @param {Audiolet} audiolet The audiolet object.
  * @param {Number} numberOfInputs The number of inputs.
  * @param {Number} numberOfOutputs The number of outputs.
+ * @param {Number} midiIn The input index to use for midi in.
+ * @param {Number} midiOut The output index to use for midi out.
  */
 var MidiGroup = function(audiolet, numberOfInputs, numberOfOutputs, midiIn, midiOut) {
     this.audiolet = audiolet;

--- a/src/midi/MidiGroup.js
+++ b/src/midi/MidiGroup.js
@@ -1,0 +1,54 @@
+/**
+ * A container for collections of connected AudioletNodes.  Groups make it
+ * possible to create multiple copies of predefined networks of nodes,
+ * without having to manually create and connect up each individual node.
+ *
+ * From the outside groups look and behave exactly the same as nodes.
+ * Internally you can connect nodes directly to the group's inputs and
+ * outputs, allowing connection to nodes outside of the group.
+ *
+ * @constructor
+ * @param {Audiolet} audiolet The audiolet object.
+ * @param {Number} numberOfInputs The number of inputs.
+ * @param {Number} numberOfOutputs The number of outputs.
+ */
+var MidiGroup = function(audiolet, numberOfInputs, numberOfOutputs, midiIn, midiOut) {
+    this.audiolet = audiolet;
+
+    this.inputs = [];
+    for (var i = 0; i < numberOfInputs; i++) {
+        if (i == midiIn) {
+            this.inputs.push(new MidiInput(this, 1, 1));
+        } else {
+            this.inputs.push(new PassThroughNode(this.audiolet, 1, 1));
+        }
+    }
+
+    this.outputs = [];
+    for (var i = 0; i < numberOfOutputs; i++) {
+        if (i == midiOut) {
+            this.outputs.push(new MidiOutput(this, 1, 1));
+         } else {
+            this.outputs.push(new PassThroughNode(this.audiolet, 1, 1));
+        }
+    }
+};
+extend(MidiGroup, AudioletGroup);
+
+MidiGroup.prototype.channels = {
+    144: 'noteOn',
+    128: 'noteOff'
+};
+
+MidiGroup.prototype.midi = function(channel, key, vel) {
+    var method = this[this.channels[channel]].bind(this);
+    method(key, vel);
+};
+
+MidiGroup.prototype.noteOn = function(key, vel) {
+    this.outputs[0].send(144, key, vel);
+};
+
+MidiGroup.prototype.noteOff = function(key, vel) {
+    this.outputs[0].send(128, key, vel);
+};

--- a/src/midi/MidiInput.js
+++ b/src/midi/MidiInput.js
@@ -1,0 +1,11 @@
+/**
+ * Class representing a single input of an AudioletNode
+ *
+ * @constructor
+ * @param {AudioletNode} node The node which the input belongs to.
+ * @param {Number} index The index of the input.
+ */
+var MidiInput = function(node, index) {
+    AudioletInput.apply(this, arguments);
+};
+extend(MidiInput, AudioletInput);

--- a/src/midi/MidiInput.js
+++ b/src/midi/MidiInput.js
@@ -1,5 +1,5 @@
 /**
- * Class representing a single input of an AudioletNode
+ * Class representing a midi input of a MidiGroup
  *
  * @constructor
  * @param {AudioletNode} node The node which the input belongs to.

--- a/src/midi/MidiKeyboard.js
+++ b/src/midi/MidiKeyboard.js
@@ -1,0 +1,47 @@
+var MidiKeyboard = function(audiolet) {
+    MidiGroup.call(this, audiolet, 0, 1, null, 0);
+    this._pressed = {};
+    document.addEventListener('keydown', this.tryNoteOn.bind(this));
+    document.addEventListener('keyup', this.tryNoteOff.bind(this));
+};
+extend(MidiKeyboard, MidiGroup);
+
+// this maps e.which values to midi note values.
+// for instance, 'G' on the keyboard is `70`,
+// which maps to midi key `71`, or, middle C
+MidiKeyboard.prototype.scale = {
+    65: 64,
+    87: 65,
+    83: 67,
+    69: 68,
+    68: 69,
+    82: 70,
+    70: 71,
+    71: 72,
+    89: 73,
+    72: 74,
+    85: 75,
+    74: 76,
+    75: 78,
+    79: 79,
+    76: 80,
+    80: 81
+};
+
+MidiKeyboard.prototype.tryNoteOn = function(e) {
+    var eventKey = e.which,
+        midiKey = this.scale[eventKey];
+    if (!this._pressed[eventKey] && midiKey) {
+        this._pressed[eventKey] = true;
+        this.outputs[0].send(144, midiKey, 255);
+    }
+};
+
+MidiKeyboard.prototype.tryNoteOff = function(e) {
+    var eventKey = e.which,
+        midiKey = this.scale[eventKey];
+    if (this._pressed[eventKey] && midiKey) {
+        this._pressed[eventKey] = false;
+        this.outputs[0].send(128, midiKey, 255);
+    }
+};

--- a/src/midi/MidiKeyboard.js
+++ b/src/midi/MidiKeyboard.js
@@ -1,4 +1,11 @@
-var MidiKeyboard = function(audiolet) {
+/**
+ * A MidiKeyboard simply broadcasts MIDI messages on a single MIDI output,
+ * based on events fired from keyboard input.
+ *
+ * @constructor
+ * @param {Audiolet} audiolet The audiolet object.
+ */
+ var MidiKeyboard = function(audiolet) {
     MidiGroup.call(this, audiolet, 0, 1, null, 0);
     this._pressed = {};
     document.addEventListener('keydown', this.tryNoteOn.bind(this));

--- a/src/midi/MidiOutput.js
+++ b/src/midi/MidiOutput.js
@@ -1,0 +1,25 @@
+/**
+ * Class representing a single output of an AudioletNode
+ *
+ * @constructor
+ * @param {AudioletNode} node The node which the input belongs to.
+ * @param {Number} index The index of the input.
+ */
+var MidiOutput = function(node, index) {
+    AudioletOutput.apply(this, arguments);
+};
+extend(MidiOutput, AudioletOutput);
+
+MidiOutput.prototype.connect = function(input) {
+    var midiInput;
+    for (var i = 0; i < input.inputs.length; i++) {
+        if (input.inputs[i] instanceof MidiInput) {
+            midiInput = input.inputs[i];
+        }
+    };
+    this.connectedTo = midiInput;
+};
+
+MidiOutput.prototype.send = function(channel, key, vel) {
+    this.connectedTo.node.midi(channel, key, vel);
+};

--- a/src/midi/MidiOutput.js
+++ b/src/midi/MidiOutput.js
@@ -1,5 +1,5 @@
 /**
- * Class representing a single output of an AudioletNode
+ * Class representing a midi output of a MidiGroup
  *
  * @constructor
  * @param {AudioletNode} node The node which the input belongs to.


### PR DESCRIPTION
this is in reference to issue #38. i couldn't wait so i went ahead at a first pass. i hosted examples of the [basic midi control](http://catshirt.net/Audiolet/examples/midi-control/index.htm) and [an arpeggiator](http://catshirt.net/Audiolet/examples/arpeggiator/index.htm). i hope the documentation/examples sufficiently explain the commit.

i did realize too late, that both instrument and arpeggiation control groups really only make sense with some frequency lookup, which would be made much easier with something like music.js. for now- the notes are all just relative frequencies with no math behind them.

so there's a few minor issues, but i figured i'd get your feedback before moving forward.

thanks!
